### PR TITLE
Remove dependency for Twilio Video

### DIFF
--- a/functions/api/token.js
+++ b/functions/api/token.js
@@ -7,14 +7,10 @@ const admin = require('firebase-admin');
 try {admin.initializeApp(functions.config().firebase);} catch(e) {} // You do that because the admin SDK can only be initialized once.
 var db = admin.firestore();
 var randomName = require('../randomname');
-var AccessToken = require('twilio').jwt.AccessToken;
-var VideoGrant = AccessToken.VideoGrant;
 
 // [END functionsimport]
 // ---------------------------------------------------------------------------
 // [START additionalimports]
-
-
 
 // [END additionalimports]
 // ---------------------------------------------------------------------------
@@ -76,32 +72,9 @@ exports = module.exports = functions.https.onRequest(async(request, response) =>
       return;
     }
     
-    
-
-
-
-
-    // Create an access token which we will sign and return to the client,
-    // containing the grant we just created.
-    var token = new AccessToken(
-        functions.config().twilio.account_sid,
-        functions.config().twilio.api_key,
-        functions.config().twilio.api_secret,
-      { ttl: MAX_ALLOWED_SESSION_DURATION }
-    );
-  
-    // Assign the generated identity to the token.
-    token.identity = identity;
-  
-    // Grant the access token Twilio Video capabilities.
-    var grant = new VideoGrant();
-    token.addGrant(grant);
-  
-    // Serialize the token to a JWT string and include it in a JSON response.
     response.send({
       room_name: room_name,
       identity: identity,
-      token: token.toJwt(),
       user_info: decodedIdToken
     });
 });

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,9 +9,7 @@
     "firebase": "",
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^3.3.0",
-    "request": "",
-    "twilio": "^3.19.1",
-    "twilio-video": "^2.28.1"
+    "request": ""
   },
   "private": true,
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -31,10 +31,6 @@
     <div id="remote-media"></div>
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-    <script src="//media.twiliocdn.com/sdk/js/video/releases/2.2.0/twilio-video.min.js"></script>
-    <script>
-      const Video = Twilio.Video;
-    </script>
     <script src="/js/auth.js"></script>
     <script src="/js/room.js"></script>
    


### PR DESCRIPTION
Fixes #34

Remove dependency on Twilio Video and replace with WebRTC.

* **functions/api/token.js**
  - Remove import of `twilio` and `twilio-video`.
  - Remove creation of `AccessToken` and `VideoGrant`.
  - Update response to include only `room_name`, `identity`, and `user_info`.

* **functions/package.json**
  - Remove `twilio` and `twilio-video` from dependencies.

* **public/index.html**
  - Remove script tag for Twilio Video.
  - Remove inline script that initializes Twilio Video.

* **public/js/room.js**
  - Remove import and usage of Twilio Video.
  - Implement WebRTC for connecting to rooms and handling video tracks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/modest-chat/issues/34?shareId=2f4fdab1-f5ab-4816-a9c4-0e356ea47be8).