### PR TITLE
Create test suite

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,11 @@
   },
   "private": true,
   "devDependencies": {
-    "firebase-functions-test": "^0.1.6"
+    "firebase-functions-test": "^0.1.6",
+    "mocha": "^9.1.3",
+    "chai": "^4.3.4"
+  },
+  "scripts": {
+    "test": "mocha --timeout 10000"
   }
 }

--- a/functions/test/token.test.js
+++ b/functions/test/token.test.js
@@ -1,0 +1,110 @@
+const firebaseFunctionsTest = require('firebase-functions-test');
+const chai = require('chai');
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const sinon = require('sinon');
+
+const expect = chai.expect;
+
+const test = firebaseFunctionsTest({
+  databaseURL: 'https://<your-project-id>.firebaseio.com',
+  storageBucket: '<your-project-id>.appspot.com',
+  projectId: '<your-project-id>',
+});
+
+describe('Token Function', () => {
+  let myFunctions;
+  let adminInitStub;
+
+  before(() => {
+    myFunctions = require('../api/token');
+    adminInitStub = sinon.stub(admin, 'initializeApp');
+  });
+
+  after(() => {
+    test.cleanup();
+    adminInitStub.restore();
+  });
+
+  it('should return a token for a valid request', async () => {
+    const req = {
+      query: {
+        room: 'test-room',
+      },
+      headers: {
+        authorization: 'Bearer valid-token',
+      },
+      cookies: {},
+    };
+
+    const res = {
+      status: sinon.stub().returnsThis(),
+      send: sinon.stub(),
+    };
+
+    const decodedIdToken = {
+      name: 'test-user',
+      uid: 'test-uid',
+    };
+
+    sinon.stub(admin.auth(), 'verifyIdToken').resolves(decodedIdToken);
+
+    await myFunctions(req, res);
+
+    expect(res.status.calledOnceWith(200)).to.be.true;
+    expect(res.send.calledOnce).to.be.true;
+    expect(res.send.firstCall.args[0]).to.deep.equal({
+      room_name: 'test-room',
+      identity: 'test-user',
+      user_info: decodedIdToken,
+    });
+
+    admin.auth().verifyIdToken.restore();
+  });
+
+  it('should return 403 for an invalid token', async () => {
+    const req = {
+      query: {
+        room: 'test-room',
+      },
+      headers: {
+        authorization: 'Bearer invalid-token',
+      },
+      cookies: {},
+    };
+
+    const res = {
+      status: sinon.stub().returnsThis(),
+      send: sinon.stub(),
+    };
+
+    sinon.stub(admin.auth(), 'verifyIdToken').rejects(new Error('Invalid token'));
+
+    await myFunctions(req, res);
+
+    expect(res.status.calledOnceWith(403)).to.be.true;
+    expect(res.send.calledOnceWith('Unauthorized')).to.be.true;
+
+    admin.auth().verifyIdToken.restore();
+  });
+
+  it('should return 403 if no token is provided', async () => {
+    const req = {
+      query: {
+        room: 'test-room',
+      },
+      headers: {},
+      cookies: {},
+    };
+
+    const res = {
+      status: sinon.stub().returnsThis(),
+      send: sinon.stub(),
+    };
+
+    await myFunctions(req, res);
+
+    expect(res.status.calledOnceWith(403)).to.be.true;
+    expect(res.send.calledOnceWith('Unauthorized')).to.be.true;
+  });
+});


### PR DESCRIPTION
Fixes #35

Add a test suite for the `token` function using Mocha and Chai.

* **functions/package.json**
  - Add `mocha` and `chai` as dev dependencies.
  - Add a test script: `"test": "mocha --timeout 10000"`.

* **functions/test/token.test.js**
  - Create a new test file for the `token` function.
  - Import `firebase-functions-test`, `chai`, `firebase-functions`, `admin`, and `sinon`.
  - Initialize `firebase-functions-test` with the Firebase project configuration.
  - Write integration tests for the `token` function, including tests for valid requests, invalid tokens, and missing tokens.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/modest-chat/issues/35?shareId=1de1ed16-d220-4be1-b4bf-8cceb4a94677).